### PR TITLE
Moving  wcsaxes dependency to the sphinx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ env:
         - SETUP_CMD='test'
         - MAIN_CMD='python setup.py'
         - PIP_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython shapely'
+        - CONDA_DEPENDENCIES='Cython shapely wcsaxes'
 
         # If there are matplotlib or other GUI tests, uncomment the following
         # line to use the X virtual framebuffer.
-        # - SETUP_XVFB=True
+        - SETUP_XVFB=True
 
     matrix:
         # Make sure that egg_info works without dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
         - SETUP_CMD='test'
         - MAIN_CMD='python setup.py'
         - PIP_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython shapely wcsaxes'
+        - CONDA_DEPENDENCIES='Cython shapely'
 
         # If there are matplotlib or other GUI tests, uncomment the following
         # line to use the X virtual framebuffer.
@@ -49,6 +49,7 @@ matrix:
         # may run for a long time
         - python: 3.5
           env: SETUP_CMD='build_sphinx -w'
+               CONDA_DEPENDENCIES='Cython shapely wcsaxes'
 
         # Try Astropy development version
         - python: 2.7


### PR DESCRIPTION
The alternatives are
- add `PIP_DEPENDENCIES='wcsaxes'` to the globals, or
- keep your change to `CONDA_DEPENDENCIES`, but change it back to the original on the py3.3 build and add `PIP_DEPENDENCIES='wcsaxes'` there.

But since you said it's only needed for the docs build, it's better to add only to that single one.
